### PR TITLE
Remove Cloudflare, add Plausible analytics

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,14 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Co₂ordinate</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
-    <!-- Cloudflare Web Analytics -->
-    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "d9cf989a05a04d1fb76e63429cfb3f0b"}'></script>
-    <!-- End Cloudflare Web Analytics -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <script
+      defer
+      data-domain="developmentseed.org/co2ordinate"
+      src="https://plausible.io/js/script.js"
+    ></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
Cloudflare analytics seemed to no longer be working. This PR moves analytics to Plausible and will close https://github.com/developmentseed/co2ordinate/pull/38